### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
 
 python:
-    - "2.6"
-    - "2.7"
-    - "pypy"
-    - "3.3"
-    - "3.4"
+    - "3.6"
+    - "3.7-dev"
 
 matrix:
     allow_failures:
@@ -13,8 +10,6 @@ matrix:
         - python: "pypy"
 
 install:
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install unittest2; fi
-    - pip install future
     - python setup.py install --quiet
     - pip install --quiet pytest-cov
 


### PR DESCRIPTION
This should drop all Py2 versions that are decades old and make things work for what should.

P.S. nosetests would fail, because codebase has wrong except blocks that aren't to Python 3.6+ standards.